### PR TITLE
Refine scan output layout

### DIFF
--- a/lilac/cli/main.py
+++ b/lilac/cli/main.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from lilac.adapters import load_resources, load_spec, write_resource
 from lilac.domain.validation import validate_against_spec
 from lilac.services import plan_changes, scan_resources
+from lilac.utils.helpers import sanitize_filename
 
 @click.group()
 def main() -> None:
@@ -41,7 +42,13 @@ def scan(namespace: str, output_dir: str) -> None:
         out_dir = Path(output_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
         for idx, res in enumerate(resources):
-            file_path = out_dir / f"{res.resource_type}_{idx}.yaml"
+            dir_path = out_dir / res.resource_type
+            dir_path.mkdir(parents=True, exist_ok=True)
+            base_name = str(
+                res.properties.get("name") or res.properties.get("id") or idx
+            )
+            safe_name = sanitize_filename(base_name)
+            file_path = dir_path / f"{safe_name}.yaml"
             write_resource(res, file_path)
     except Exception as exc:  # pragma: no cover - tested via CliRunner
         raise click.ClickException(str(exc))

--- a/lilac/utils/__init__.py
+++ b/lilac/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility helpers for Lilac."""
 
-from .helpers import helper
+from .helpers import helper, sanitize_filename
 
-__all__ = ["helper"]
+__all__ = ["helper", "sanitize_filename"]

--- a/lilac/utils/helpers.py
+++ b/lilac/utils/helpers.py
@@ -1,3 +1,9 @@
 def helper() -> bool:
     """Utility helper placeholder."""
     return True
+
+
+def sanitize_filename(name: str) -> str:
+    """Return ``name`` converted to a bash-safe filename."""
+    safe = name.replace("/", "_").replace(" ", "_")
+    return safe

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -105,7 +105,27 @@ def test_scan_success(tmp_path, monkeypatch) -> None:
     )
 
     assert result.exit_code == 0
-    assert (tmp_path / "s3-bucket_0.yaml").exists()
+    assert (tmp_path / "s3-bucket" / "bucket.yaml").exists()
+
+
+def test_scan_sanitizes_name(tmp_path, monkeypatch) -> None:
+    res = Resource(
+        resource_type="s3-bucket",
+        namespace="prod",
+        depends_on=[],
+        properties={"name": "my bucket/v1"},
+    )
+    cli_main = importlib.import_module("lilac.cli.main")
+    monkeypatch.setattr(cli_main, "scan_resources", lambda ns: [res])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["scan", "--namespace", "prod", "--output-dir", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    assert (tmp_path / "s3-bucket" / "my_bucket_v1.yaml").exists()
 
 
 def test_scan_failure(monkeypatch) -> None:

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,5 +1,9 @@
-from lilac.utils.helpers import helper
+from lilac.utils.helpers import helper, sanitize_filename
 
 
 def test_helper() -> None:
     assert helper() is True
+
+
+def test_sanitize_filename() -> None:
+    assert sanitize_filename("my bucket/v1") == "my_bucket_v1"


### PR DESCRIPTION
## Summary
- organize output by resource type when scanning
- add helper to sanitize filenames
- extend CLI tests for new scan paths
- test filename sanitization utility

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c06e1f548832c80f861dcc8d57833